### PR TITLE
Feat : 마이 페이지 수정 및 피드 업로드 시 contents 같이 올리기 기능 추가

### DIFF
--- a/src/main/java/com/back/moment/boards/controller/BoardController.java
+++ b/src/main/java/com/back/moment/boards/controller/BoardController.java
@@ -8,6 +8,7 @@ import com.back.moment.users.entity.Users;
 import com.back.moment.users.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -30,20 +31,20 @@ public class BoardController {
         return boardService.createBoard(boardRequestDto, userDetails.getUsers(), boardImg);
     }
 
-    @GetMapping("") //게시글 전체 조회
-    public ResponseEntity<Page<BoardListResponseDto>> getAllBoards(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                   @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return boardService.getAllBoards(userDetails.getUsers(), pageable);
-    }
-
-//    @GetMapping("/boards")
-//    public ResponseEntity<Page<BoardListResponseDto>> getBoardsByPage(
-//            @AuthenticationPrincipal UserDetailsImpl userDetails,
-//            @RequestParam(defaultValue = "0") int page,
-//            @RequestParam(defaultValue = "5") int size) {
-//        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+//    @GetMapping("") //게시글 전체 조회
+//    public ResponseEntity<Page<BoardListResponseDto>> getAllBoards(@AuthenticationPrincipal UserDetailsImpl userDetails,
+//                                                                   @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 //        return boardService.getAllBoards(userDetails.getUsers(), pageable);
 //    }
+
+    @GetMapping("")
+    public ResponseEntity<Page<BoardListResponseDto>> getBoardsByPage(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        return boardService.getAllBoards(userDetails.getUsers(), pageable);
+    }
 
     // 게시글 상세 조회
     @GetMapping("/{boardId}")

--- a/src/main/java/com/back/moment/boards/service/BoardService.java
+++ b/src/main/java/com/back/moment/boards/service/BoardService.java
@@ -16,6 +16,7 @@ import com.back.moment.users.entity.Users;
 import com.back.moment.users.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -74,26 +75,26 @@ public class BoardService {
     }
 
     // 게시글 전체 조회
-    @Transactional(readOnly = true)
-    public ResponseEntity<Page<BoardListResponseDto>> getAllBoards(Users users, Pageable pageable){
-        existUser(users.getEmail());
-        Page<BoardListResponseDto> boardList = boardRepository.selectAllBoard(pageable);
-        return new ResponseEntity<>(boardList, HttpStatus.OK);
-    }
-
 //    @Transactional(readOnly = true)
-//    public ResponseEntity<Page<BoardListResponseDto>> getAllBoards(Users users, Pageable pageable) {
+//    public ResponseEntity<Page<BoardListResponseDto>> getAllBoards(Users users, Pageable pageable){
 //        existUser(users.getEmail());
 //        Page<BoardListResponseDto> boardList = boardRepository.selectAllBoard(pageable);
-//
-//        if (boardList.hasNext()) {
-//            boardList = new PageImpl<>(boardList.getContent(), pageable, boardList.getTotalElements());
-//        } else {
-//            boardList = Page.empty(pageable);
-//        }
-//
 //        return new ResponseEntity<>(boardList, HttpStatus.OK);
 //    }
+
+    @Transactional(readOnly = true)
+    public ResponseEntity<Page<BoardListResponseDto>> getAllBoards(Users users, Pageable pageable) {
+        existUser(users.getEmail());
+        Page<BoardListResponseDto> boardList = boardRepository.selectAllBoard(pageable);
+
+        if (boardList.hasNext()) {
+            boardList = new PageImpl<>(boardList.getContent(), pageable, boardList.getTotalElements());
+        } else {
+            boardList = Page.empty(pageable);
+        }
+
+        return new ResponseEntity<>(boardList, HttpStatus.OK);
+    }
 
     // 게시글 상세 조회
     @Transactional(readOnly = true)

--- a/src/main/java/com/back/moment/exception/ExceptionEnum.java
+++ b/src/main/java/com/back/moment/exception/ExceptionEnum.java
@@ -29,6 +29,7 @@ public enum ExceptionEnum {
 
     // 409 Conflict
     DUPLICATED_USER_NAME(HttpStatus.CONFLICT, "409", "중복된 이메일이 존재합니다."),
+    DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "409", "중복된 닉네임이 존재합니다."),
 
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "서버에러");

--- a/src/main/java/com/back/moment/feed/controller/FeedController.java
+++ b/src/main/java/com/back/moment/feed/controller/FeedController.java
@@ -26,8 +26,10 @@ public class FeedController {
 
     // feed 업로드
     @PostMapping(value = "", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
-    public ResponseEntity<Void> uploadImages(@RequestPart(value = "imageFile", required = false) List<MultipartFile> imageFile, @AuthenticationPrincipal UserDetailsImpl userDetails) throws IOException {
-        return feedService.uploadImages(imageFile, userDetails.getUsers());
+    public ResponseEntity<Void> uploadImages(@RequestPart(value = "contents") FeedRequestDto feedRequestDto,
+                                             @RequestPart(value = "imageFile", required = false) List<MultipartFile> imageFile,
+                                             @AuthenticationPrincipal UserDetailsImpl userDetails) throws IOException {
+        return feedService.uploadImages(feedRequestDto, imageFile, userDetails.getUsers());
     }
 
     // Feed 에서 photo 좋아요

--- a/src/main/java/com/back/moment/feed/controller/FeedController.java
+++ b/src/main/java/com/back/moment/feed/controller/FeedController.java
@@ -3,6 +3,7 @@ package com.back.moment.feed.controller;
 import com.amazonaws.Response;
 import com.back.moment.feed.dto.FeedDetailResponseDto;
 import com.back.moment.feed.dto.FeedListResponseDto;
+import com.back.moment.feed.dto.FeedRequestDto;
 import com.back.moment.feed.service.FeedService;
 import com.back.moment.users.entity.Users;
 import com.back.moment.users.security.UserDetailsImpl;
@@ -51,6 +52,14 @@ public class FeedController {
     @GetMapping("/{photoId}")
     public ResponseEntity<FeedDetailResponseDto> getFeed(@PathVariable Long photoId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return feedService.getFeed(photoId, userDetails.getUsers());
+    }
+
+    // feed 내용 작성
+    @PutMapping("/{photoId}")
+    public ResponseEntity<Void> writeContents(@PathVariable Long photoId,
+                                              @RequestBody FeedRequestDto feedRequestDto,
+                                              @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return feedService.writeContents(photoId, feedRequestDto, userDetails.getUsers());
     }
 
 }

--- a/src/main/java/com/back/moment/feed/dto/FeedRequestDto.java
+++ b/src/main/java/com/back/moment/feed/dto/FeedRequestDto.java
@@ -1,0 +1,10 @@
+package com.back.moment.feed.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FeedRequestDto {
+    private String contents;
+}

--- a/src/main/java/com/back/moment/photos/entity/Photo.java
+++ b/src/main/java/com/back/moment/photos/entity/Photo.java
@@ -32,11 +32,19 @@ public class Photo {
     @OneToMany(mappedBy = "photo", cascade = CascadeType.ALL)
     private List<Love> loveList = new ArrayList<>();
 
+    @ColumnDefault("사진 한줄 요약")
+    private String contents;
+
     @ColumnDefault("0")
     private int loveCnt;
 
-    public Photo(Users users, String imagUrl) {
+    public Photo(Users users, String contents, String imagUrl) {
         this.users = users;
+        this.contents = contents;
         this.imagUrl = imagUrl;
+    }
+
+    public void updateContents(String contents){
+        this.contents = contents;
     }
 }

--- a/src/main/java/com/back/moment/users/controller/MyPageController.java
+++ b/src/main/java/com/back/moment/users/controller/MyPageController.java
@@ -19,9 +19,9 @@ import java.io.IOException;
 public class MyPageController {
     private final MyPageService myPageService;
 
-    @GetMapping("/{nickName}")
-    public ResponseEntity<MyPageResponseDto> getMyPage(@PathVariable String nickName, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return myPageService.getMyPage(nickName, userDetails.getUsers());
+    @GetMapping("/{hostId}")
+    public ResponseEntity<MyPageResponseDto> getMyPage(@PathVariable Long hostId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return myPageService.getMyPage(hostId, userDetails.getUsers());
     }
 
     @DeleteMapping("/{photoId}")

--- a/src/main/java/com/back/moment/users/controller/MyPageController.java
+++ b/src/main/java/com/back/moment/users/controller/MyPageController.java
@@ -1,12 +1,17 @@
 package com.back.moment.users.controller;
 
 import com.back.moment.users.dto.MyPageResponseDto;
+import com.back.moment.users.dto.UpdateRequestDto;
 import com.back.moment.users.security.UserDetailsImpl;
 import com.back.moment.users.service.MyPageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,4 +30,11 @@ public class MyPageController {
     }
 
     // 마이페이지 수정 구상 중
+    @PutMapping(value = "/{hostId}", consumes = { MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE }, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> updatePage(@PathVariable Long hostId,
+                                           @RequestPart(value = "update") UpdateRequestDto updateRequestDto,
+                                           @AuthenticationPrincipal UserDetailsImpl userDetails,
+                                           @RequestPart(value = "profile", required = false) MultipartFile profileImg) throws IOException {
+        return myPageService.updateMyPage(hostId, updateRequestDto, userDetails.getUsers(), profileImg);
+    }
 }

--- a/src/main/java/com/back/moment/users/dto/UpdateRequestDto.java
+++ b/src/main/java/com/back/moment/users/dto/UpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.back.moment.users.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@NoArgsConstructor
+public class UpdateRequestDto {
+    private String nickName;
+    private String password;
+}

--- a/src/main/java/com/back/moment/users/entity/Users.java
+++ b/src/main/java/com/back/moment/users/entity/Users.java
@@ -5,6 +5,7 @@ import com.back.moment.love.entity.Love;
 import com.back.moment.photos.entity.Photo;
 import com.back.moment.recommend.entity.Recommend;
 import com.back.moment.users.dto.SignupRequestDto;
+import com.back.moment.users.dto.UpdateRequestDto;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -76,6 +77,12 @@ public class Users {
         this.nickName = requestDto.getNickName();
         this.sex = sex;
         this.role = role;
+    }
+
+    public void updateUsers(String nickName, String profileUrl, String password){
+        this.nickName = nickName;
+        this.profileImg = profileUrl;
+        this.password = password;
     }
 
 }

--- a/src/main/java/com/back/moment/users/service/UserService.java
+++ b/src/main/java/com/back/moment/users/service/UserService.java
@@ -1,5 +1,7 @@
 package com.back.moment.users.service;
 
+import com.back.moment.exception.ApiException;
+import com.back.moment.exception.ExceptionEnum;
 import com.back.moment.s3.S3Uploader;
 import com.back.moment.users.dto.LoginRequestDto;
 import com.back.moment.users.dto.SignupRequestDto;
@@ -47,7 +49,7 @@ public class UserService {
         }
         Optional<Users> findEmail = usersRepository.findByEmail(requestDto.getEmail());
         if (findEmail.isPresent()) {
-            throw new IllegalArgumentException("이미 존재하는 이메일입니다");
+            throw new ApiException(ExceptionEnum.DUPLICATED_USER_NAME);
         }
         Users users = new Users();
         String password = passwordEncoder.encode(requestDto.getPassword());


### PR DESCRIPTION
Body : 마이 페이지 조회는 api를 통해 마이 페이지 주인이 되는 유저의 아이디를 통해 마이 페이지를 들어갈 수 있도록 하였다. 수정인 경우 api에 들어있는 아이디와 로그인한 유저의 아이디가 같은지를 판별하여 같을 경우 수정이 가능하도록 구성하였다. 피드 업로드 시 contents 같이 올리기 기능은 만약 피드를 여러 장 올릴 시 같은 contents가 저장되도록 구성하였다.