### PR TITLE
Fix : 피드 전체 조회 시 랜덤하게 정렬 제거 createdAt 기준으로 정렬 + string 문자열 출력 시 쌍따옴표 …

### DIFF
--- a/src/main/java/com/back/moment/feed/dto/FeedDetailResponseDto.java
+++ b/src/main/java/com/back/moment/feed/dto/FeedDetailResponseDto.java
@@ -32,7 +32,10 @@ public class FeedDetailResponseDto {
         this.profileUrl = photo.getUsers().getProfileImg();
         this.nickName = photo.getUsers().getNickName();
         this.role = photo.getUsers().getRole();
-        this.contents = photo.getContents();
+        String contents = photo.getContents();
+        if (contents != null && !contents.isEmpty()) {
+            this.contents = contents;
+        }
         this.tag_photoList = photo.getTagListWithWell();
         this.createdTime = photo.getCreatedAt();
     }

--- a/src/main/java/com/back/moment/feed/service/FeedService.java
+++ b/src/main/java/com/back/moment/feed/service/FeedService.java
@@ -173,16 +173,14 @@ public class FeedService {
 
         // Get the top three photos
         List<PhotoFeedResponseDto> topThreePhotos = responsePhotoList.stream()
-                .limit(3)
+                .limit(4)
                 .toList();
 
         // Get the remaining photos
         List<PhotoFeedResponseDto> remainingPhotos = responsePhotoList.stream()
-                .skip(3)
-                .collect(Collectors.toList());
-
-        // Shuffle the remaining photos
-        Collections.shuffle(remainingPhotos);
+                .skip(4)
+                .sorted(Comparator.comparing(PhotoFeedResponseDto::getCreatedTime).reversed())
+                .toList();
 
         // Add the top three photos and remaining photos to the response list
         List<PhotoFeedResponseDto> finalPhotoList = new ArrayList<>();

--- a/src/main/java/com/back/moment/love/entity/Love.java
+++ b/src/main/java/com/back/moment/love/entity/Love.java
@@ -15,12 +15,12 @@ public class Love {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     @JsonIgnore
     private Users users;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     private Photo photo;
 

--- a/src/main/java/com/back/moment/photos/dto/PhotoFeedResponseDto.java
+++ b/src/main/java/com/back/moment/photos/dto/PhotoFeedResponseDto.java
@@ -36,6 +36,6 @@ public class PhotoFeedResponseDto {
         this.content = photo.getContents();
         this.tag_photoList = photo.getTagListWithWell();
         this.loveCheck = loveCheck;
-        this.createdTime = photo.getCreatedAt();
+        this.createdTime = (photo.getCreatedAt() != null) ? photo.getCreatedAt() : LocalDateTime.now();
     }
 }

--- a/src/main/java/com/back/moment/photos/entity/Photo.java
+++ b/src/main/java/com/back/moment/photos/entity/Photo.java
@@ -34,7 +34,7 @@ public class Photo extends TimeStamped {
     @Column(nullable = false)
     private String imagUrl;
 
-    @OneToMany(mappedBy = "photo", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "photo", cascade = CascadeType.ALL)
     private List<Love> loveList = new ArrayList<>();
 
     @Column
@@ -43,7 +43,7 @@ public class Photo extends TimeStamped {
     @ColumnDefault("0")
     private int loveCnt;
 
-    @OneToMany(mappedBy = "photo", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "photo", cascade = CascadeType.REMOVE)
     private List<Tag_Photo> tag_photoList = new ArrayList<>();
 
 

--- a/src/main/java/com/back/moment/photos/entity/Tag_Photo.java
+++ b/src/main/java/com/back/moment/photos/entity/Tag_Photo.java
@@ -14,11 +14,11 @@ public class Tag_Photo {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JsonIgnore
     private PhotoHashTag photoHashTag;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JsonIgnore
     private Photo photo;
 

--- a/src/main/java/com/back/moment/photos/repository/PhotoRepository.java
+++ b/src/main/java/com/back/moment/photos/repository/PhotoRepository.java
@@ -28,4 +28,7 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     @Query("SELECT p.id, CASE WHEN (COUNT(l) > 0) THEN true ELSE false END FROM Photo p LEFT JOIN p.loveList l ON l.users.id = :usersId WHERE p.id IN :photoIdList GROUP BY p.id")
     List<Object[]> checkLoveList(@Param("photoIdList") List<Long> photoIdList, @Param("usersId") Long usersId);
 
+    @Query("delete from Photo p where p.id = :photoId")
+    void removeFeed(@Param("photoId") Long photoId);
+
 }

--- a/src/main/java/com/back/moment/photos/repository/Tag_PhotoRepository.java
+++ b/src/main/java/com/back/moment/photos/repository/Tag_PhotoRepository.java
@@ -2,6 +2,8 @@ package com.back.moment.photos.repository;
 
 import com.back.moment.photos.entity.Tag_Photo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface Tag_PhotoRepository extends JpaRepository<Tag_Photo, Long> {
+    void deleteAllByPhotoId(@Param("photoId") Long photoId);
 }

--- a/src/main/java/com/back/moment/users/controller/MyPageController.java
+++ b/src/main/java/com/back/moment/users/controller/MyPageController.java
@@ -24,7 +24,7 @@ public class MyPageController {
         return myPageService.getMyPage(hostId, userDetails.getUsers());
     }
 
-    @DeleteMapping("/{photoId}")
+    @DeleteMapping ("/{photoId}")
     public ResponseEntity<String> deletePhoto(@PathVariable Long photoId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return myPageService.deletePhoto(photoId, userDetails.getUsers());
     }

--- a/src/main/java/com/back/moment/users/entity/Users.java
+++ b/src/main/java/com/back/moment/users/entity/Users.java
@@ -50,13 +50,13 @@ public class Users {
 //    @Column(nullable = false)
 //    private boolean userDelete = false;
 
-    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Photo> photoList = new ArrayList<>();
 
     @OneToMany(mappedBy = "users", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Love> loveList = new ArrayList<>();  //좋아요(내가 좋아요 누른 사진 목록)
 
-    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Board> boardList = new ArrayList<>();
 
 //    @OneToMany(mappedBy = "recommender", cascade = CascadeType.ALL)


### PR DESCRIPTION
…제거하도록 수정